### PR TITLE
Limited Redis client instance creation to main module

### DIFF
--- a/server-cluster.js
+++ b/server-cluster.js
@@ -1,0 +1,36 @@
+var cluster = require('cluster');
+var http = require('http');
+var numCPUs = require('os').cpus().length;
+// var redis = require('redis');
+// var client = redis.createClient();
+
+if (cluster.isMaster) {
+  for (var i = 0; i < numCPUs; i++) {
+    cluster.fork();
+  }
+// } else {
+// 	http.createServer(function(request, response) {
+//     client.hgetall('perftest', function(err, results) {
+//   		response.writeHead(200, { 'Content-Type': 'application/json'});
+//   		response.write(JSON.stringify(results));
+//   		response.end();
+//   	});
+// 	}).listen(3001, function() {
+// 		console.log('listener spun up on localhost:3001')
+// 	});
+// }
+
+// other way, creating a client per forked thread
+} else {
+  var redis = require('redis');
+  var client = redis.createClient();
+	http.createServer(function(request, response) {
+    client.hgetall('keystone:dynatron/metric::ebis-wlri-analysis:info', function(err, results) {
+  		response.writeHead(200, { 'Content-Type': 'application/json'});
+  		response.write(JSON.stringify(results));
+  		response.end();
+  	});
+	}).listen(3000, function() {
+		console.log('listener spun up on localhost:3000')
+	});
+}

--- a/server.go
+++ b/server.go
@@ -3,23 +3,29 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"runtime"
+
 	"gopkg.in/redis.v3"
 )
 
-func handler(w http.ResponseWriter, r *http.Request) {
-	//fmt.Fprint(w, "Hello World!");
-	client := redis.NewClient(&redis.Options{
-		Addr: "localhost:6379",
-		Password: "",
-		DB: 0,
-	})
+type Server struct {
+	db *redis.Client
+}
 
-	results, _ := client.HGetAll("keystone:dynatron/metric::ebis-wlri-analysis:info").Result()
+func (s *Server) handler(w http.ResponseWriter, r *http.Request) {
+	results, _ := s.db.HGetAll("keystone:dynatron/metric::ebis-wlri-analysis:info").Result()
 	fmt.Fprint(w, results)
-	//fmt.Printf("The type is: %s \n", results)
 }
 
 func main() {
-	http.HandleFunc("/", handler)
-	http.ListenAndServe(":3000", nil);
+	runtime.GOMAXPROCS(1)
+	client := redis.NewClient(&redis.Options{
+		Addr:     "localhost:6379",
+		Password: "",
+		DB:       0,
+	})
+	server := &Server{db: client}
+
+	http.HandleFunc("/", server.handler)
+	http.ListenAndServe(":3000", nil)
 }

--- a/server.go
+++ b/server.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"net/http"
-	"runtime"
 
 	"gopkg.in/redis.v3"
 )
@@ -18,7 +17,6 @@ func (s *Server) handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	runtime.GOMAXPROCS(1)
 	client := redis.NewClient(&redis.Options{
 		Addr:     "localhost:6379",
 		Password: "",


### PR DESCRIPTION
Noticed the creation of a new redis client per every request has a significant bottleneck. Since you aren't creating a client per request in the nodejs version, this seems a bit more fair -- after the change, I found golang now beats out nodejs even at a concurrency of 1 when running apache bench (from 1.266 [ms](mean) prechange to 0.588 [ms](mean) postchange).
